### PR TITLE
Bot-Fixed the error of invoking FB send message due to missing imageurl  

### DIFF
--- a/bot/messenger/app.js
+++ b/bot/messenger/app.js
@@ -539,6 +539,11 @@ function callSendAPI(sender_psid, response) {
             console.log('HTTP Response Status Code:', res && res.statusCode);
             console.log('Body:', JSON.stringify(body));
             console.error("Unable to send message:" + err);
+            if(body && body.error && body.error.message)
+            {
+                let msg = `${i18n.FBMessageAPIErrorReply} ${body.error.message}`;
+                callSendAPI(sender_psid, intentHelper.GenerateTextResponse(msg));
+            }
         }
     });
 }

--- a/bot/messenger/i18n.js
+++ b/bot/messenger/i18n.js
@@ -1,33 +1,34 @@
-exports.Welcome = "Hello, Welcome to SAP SMB Market Place. I am Milton, your virtual assistant. What can I help?";
-exports.GoodByeResponse = "Good bye. Have a nice day.";
-exports.GoodByeResponse2 = "It is nice to talk with you. Good bye.";
-exports.ThankYouResponse = "My pleasure, Master.";
-exports.ThankYouResponse2 = "You are welcome, Master.";
-exports.NoDataResponse = "No data";
-exports.LoginErrorResponse = "Hello, I am Milton, your virtual assistant. Sorry but I can't login at this time.";
-exports.ErrorResponse = "Sorry, but it is beyond of me. Please check your question.";
+exports.Welcome = 'Hello, Welcome to SAP SMB Market Place. I am Milton, your virtual assistant. What can I help?';
+exports.GoodByeResponse = 'Good bye. Have a nice day.';
+exports.GoodByeResponse2 = 'It is nice to talk with you. Good bye.';
+exports.ThankYouResponse = 'My pleasure, Master.';
+exports.ThankYouResponse2 = 'You are welcome, Master.';
+exports.NoDataResponse = 'No data';
+exports.LoginErrorResponse = `Hello, I am Milton, your virtual assistant. Sorry but I can't login at this time.`;
+exports.ErrorResponse = 'Sorry, but it is beyond of me. Please check your question.';
 exports.BotNameIntentReply1 = 'My name is Milton, your virtual assistant. I can help you to find the similar products in the SAP SMB Market Place(B1&ByD) with a picture, and keep learning and elvolving to serve you better.';
 exports.BotNameIntentReply2 = 'I am Milton, your virtual assistant. At the present moment, I can help you to find out the similar products in the SAP SMB Market Place(B1&ByD) with a picture. I am powered by SAP Leonardo Machine Learning Foundation, still keep learning and evolving.';
-exports.BotGenderIntentReply1 = "Milton sounds like a boy. So I should be a guy.";
-exports.BotGenderIntentReply2 = "Some time I am a naughty boy.";
-exports.BotAgeIntentReply1 = "I won't tell you that I am just born.";
+exports.BotGenderIntentReply1 = 'Milton sounds like a boy. So I should be a guy.';
+exports.BotGenderIntentReply2 = 'Some time I am a naughty boy.';
+exports.BotAgeIntentReply1 = `I won't tell you that I am just born.`;
 exports.BotAgeIntentReply2 = 'hmhm, my back-end system SAP Business One is already 20 years old and SAP Business By Design 10 years old. I just start my journey.';
-exports.BotCreatorIntentReply1 = "Aha, thanks to Yatsea/Ralph/Thiago/Eddy for giving me a life on Facebook Messenger. One day, I wish I could have my own children.";
-exports.BotCreatorIntentReply2 = "My brain is running in SAP Leonardo by Ralph/Thiago/Eddy. Facebook Messenger Bot is just one of my faces created by Yatsea.";
-exports.B1MovieStarIntentReply1 = "You mean the Italian guy-Gianluigi Bagnoli";
-exports.B1MovieStarIntentReply2 = "Finn Backer";
-exports.ComplementIntentReply1 = "Thank you for the complement.";
-exports.ComplementIntentReply2 = "Glad to hear that.";
-exports.ShowCartIntentReply = "You can check your shopping cart from the menu(My Shopping Cart) or through this url: https://sap-smbassistantbot.cfapps.eu10.hana.ondemand.com/web/ShoppingCart";
+exports.BotCreatorIntentReply1 = 'Aha, thanks to Yatsea/Ralph/Thiago/Eddy for giving me a life on Facebook Messenger. One day, I wish I could have my own children.';
+exports.BotCreatorIntentReply2 = 'My brain is running in SAP Leonardo by Ralph/Thiago/Eddy. Facebook Messenger Bot is just one of my faces created by Yatsea.';
+exports.B1MovieStarIntentReply1 = 'You mean the Italian guy-Gianluigi Bagnoli';
+exports.B1MovieStarIntentReply2 = 'Finn Backer';
+exports.ComplementIntentReply1 = 'Thank you for the complement.';
+exports.ComplementIntentReply2 = 'Glad to hear that.';
+exports.ShowCartIntentReply = 'You can check your shopping cart from the menu(My Shopping Cart) or through this url: https://sap-smbassistantbot.cfapps.eu10.hana.ondemand.com/web/ShoppingCart';
 exports.HelpIntentReply = `At the present moment, I can help with below:
 1.Send me a photo of a product(shoe) you are looking for. I will get you the best matched ones on SAP SMB Market Place.
 2.You can view the product detail to start shopping online. Or you can check the physical store of the shoes on map.
 3.Ask me about my age, gender or creator, or b1 movie star etc. 
 4.Ask for help manual.`;
-exports.InvalidAttachmentTypeReply = "Invalid attachment type. Please upload an image of product(shoes).";
-exports.NoMatchedProductReply = "No matched product found on the market place.";
-exports.GenericAPIErrorReply = "An error has occurred on invoking api.";
-exports.ImageResolutionErrReply = "Image too resolution high. Max accepted resolution as 1024px x 768px. Please resize the image and try again.";
+exports.InvalidAttachmentTypeReply = 'Invalid attachment type. Please upload an image of product(shoes).';
+exports.NoMatchedProductReply = 'No matched product found on the market place.';
+exports.GenericAPIErrorReply = 'An error has occurred on invoking api.';
+exports.FBMessageAPIErrorReply = 'An error has occurred on invoking Facebook send message API. Reason:';
+exports.ImageResolutionErrReply = 'Image too resolution high. Max accepted resolution as 1024px x 768px. Please resize the image and try again.';
 exports.GreetingIntent = 'Greeting';
 exports.ThankYouIntent = 'ThankYou';
 exports.GoodByeIntent = 'GoodBye';


### PR DESCRIPTION
Fixed the error of invoking FB send message due to missing image_url  of items in ERP.
Previous behaviour: Bot is not able to send any reply message to ender user.
Current behaviour: Bot sends the message about the exact error.
for example: An error has occurred on invoking Facebook send message API. Reason: (#100) image_url is required for top item with large style in list template message  